### PR TITLE
Use parent POM version for versioning all sub-modules and their cross-dependencies

### DIFF
--- a/application-api/pom.xml
+++ b/application-api/pom.xml
@@ -25,20 +25,15 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>application-api</artifactId>
-    <version>0.10.0</version>
 
     <name>application-api</name>
     <description>Application API</description>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/client-api/pom.xml
+++ b/client-api/pom.xml
@@ -25,20 +25,15 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>client-api</artifactId>
-    <version>0.10.0</version>
 
     <name>client-server-api</name>
     <description>Client-Server API</description>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/common-api/pom.xml
+++ b/common-api/pom.xml
@@ -25,7 +25,6 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>common-api</artifactId>
-    <version>0.10.0</version>
 
     <name>common-api</name>
     <description>Common Matrix classes: Id, Events, ...</description>

--- a/identity-api/pom.xml
+++ b/identity-api/pom.xml
@@ -25,20 +25,15 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>identity-api</artifactId>
-    <version>0.10.0</version>
 
     <name>identity-api</name>
     <description>Identity API</description>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/push-api/pom.xml
+++ b/push-api/pom.xml
@@ -25,20 +25,15 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>push-api</artifactId>
-    <version>0.10.0</version>
 
     <name>push-api</name>
     <description>Push API</description>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/server-api/pom.xml
+++ b/server-api/pom.xml
@@ -25,20 +25,15 @@
         <version>0.10.0</version>
     </parent>
     <artifactId>server-api</artifactId>
-    <version>0.10.0</version>
 
     <name>server-server-api</name>
     <description>Server-Server API</description>
-
-    <properties>
-        <version.lib.common-api>0.9.2-SNAPSHOT</version.lib.common-api>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.github.ma1uta.matrix</groupId>
             <artifactId>common-api</artifactId>
-            <version>${version.lib.common-api}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
fix #3

I recommend using `mvn release:prepare` and `mvn release:clean` to avoid similar issues in the future. Also some basic job on Travis CI running just `mvn install` would uncover that.