### PR TITLE
E2EE: Added missing Json[b]Property annotations

### DIFF
--- a/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/DeviceKeys.java
+++ b/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/DeviceKeys.java
@@ -84,6 +84,7 @@ public class DeviceKeys {
     @Schema(
         description = "Additional data added to the device key information by intermediate servers, and not covered by the signatures."
     )
+    @JsonbProperty("unsigned")
     private UnsignedDeviceInfo unsignedDeviceInfo;
 
     @JsonProperty("user_id")
@@ -128,6 +129,7 @@ public class DeviceKeys {
         this.signatures = signatures;
     }
 
+    @JsonProperty("unsigned")
     public UnsignedDeviceInfo getUnsignedDeviceInfo() {
         return unsignedDeviceInfo;
     }


### PR DESCRIPTION
Fixed a [spec](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-keys-query) issue (breaks device key signing)

Please push a new release for jeon and jmsdk (with updated dependency) if you merge this PR 😏 

Cheers