### PR TITLE
E2EE: Include empty list of device keys in serialized request body

### DIFF
--- a/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/QueryRequest.java
+++ b/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/QueryRequest.java
@@ -16,6 +16,7 @@
 
 package io.github.ma1uta.matrix.client.model.encryption;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -71,6 +72,7 @@ public class QueryRequest {
     }
 
     @JsonProperty("device_keys")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Map<String, List<String>> getDeviceKeys() {
         return deviceKeys;
     }


### PR DESCRIPTION
* This currently breaks E2EE
* Spec: https://matrix.org/docs/spec/client_server/latest#post-matrix-client-r0-keys-query
* Note: this fixes Jackson only (JSON-B untested/unchanged)