### PR TITLE
Added serialization support for DeviceKeys objects

### DIFF
--- a/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/DeviceKeys.java
+++ b/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/DeviceKeys.java
@@ -19,9 +19,11 @@ package io.github.ma1uta.matrix.client.model.encryption;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbTransient;
 
 /**
  * Device Keys.
@@ -29,7 +31,10 @@ import javax.json.bind.annotation.JsonbProperty;
 @Schema(
     description = "Device keys."
 )
-public class DeviceKeys {
+public class DeviceKeys implements Serializable {
+
+    @JsonbTransient
+    private static final long serialVersionUID = 1727882109027072362L;
 
     /**
      * Required. The ID of the user the device belongs to. Must match the user ID used when logging in.

--- a/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/UnsignedDeviceInfo.java
+++ b/client-api/src/main/java/io/github/ma1uta/matrix/client/model/encryption/UnsignedDeviceInfo.java
@@ -19,7 +19,9 @@ package io.github.ma1uta.matrix.client.model.encryption;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.io.Serializable;
 import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbTransient;
 
 /**
  * UnsignedDeviceInfo.
@@ -27,7 +29,10 @@ import javax.json.bind.annotation.JsonbProperty;
 @Schema(
     description = "Unsigned device info."
 )
-public class UnsignedDeviceInfo {
+public class UnsignedDeviceInfo implements Serializable {
+
+    @JsonbTransient
+    private static final long serialVersionUID = 4184762434649188422L;
 
     /**
      * The display name which the user set on the device.


### PR DESCRIPTION
* DeviceKeys should be serialized by clients
* UnsignedDeviceInfo needs to be serializable as well (part of DeviceKeys)
* Used version UID derived on current set of properties
* Annotated UID to be ignored by JSONB