### PR TITLE
Bump maven-bundle-plugin to 5.1.2 to support latest Java releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.plugin.versions-maven-plugin>2.7</version.plugin.versions-maven-plugin>
         <version.plugin.maven-jar-plugin>3.1.0</version.plugin.maven-jar-plugin>
         <version.plugin.buildnumber-maven-plugin>1.4</version.plugin.buildnumber-maven-plugin>
-        <version.plugin.maven-bundle-plugin>4.1.0</version.plugin.maven-bundle-plugin>
+        <version.plugin.maven-bundle-plugin>5.1.2</version.plugin.maven-bundle-plugin>
 
         <!-- plugins dependencies -->
         <version.lib.checkstyle>8.41.1</version.lib.checkstyle>


### PR DESCRIPTION
The current version triggers a `ConcurrentModificationException` with Java 15, for instance.

Related: how about enabling GitHub's [Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates) on this project?

Cheers!